### PR TITLE
Use usize for contianer sizes

### DIFF
--- a/src/buttonlike_user_input.rs
+++ b/src/buttonlike_user_input.rs
@@ -98,11 +98,11 @@ impl UserInput {
     }
 
     /// The number of buttons in the [`UserInput`]
-    pub fn len(&self) -> u8 {
+    pub fn len(&self) -> usize {
         match self {
             UserInput::Null => 0,
             UserInput::Single(_) => 1,
-            UserInput::Chord(button_set) => button_set.len().try_into().unwrap(),
+            UserInput::Chord(button_set) => button_set.len(),
         }
     }
 
@@ -128,7 +128,7 @@ impl UserInput {
     /// assert_eq!(ctrl_a.n_matching(&buttons), 1);
     /// assert_eq!(ctrl_alt_a.n_matching(&buttons), 2);
     /// ```
-    pub fn n_matching(&self, buttons: &HashSet<InputButton>) -> u8 {
+    pub fn n_matching(&self, buttons: &HashSet<InputButton>) -> usize {
         match self {
             UserInput::Null => 0,
             UserInput::Single(button) => {

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -288,13 +288,13 @@ fn resolve_clash<A: Actionlike>(
         ClashStrategy::PressAll => None,
         // Remove the clashing action with the shorter chord
         ClashStrategy::PrioritizeLongest => {
-            let longest_a: u8 = reasons_a_is_pressed
+            let longest_a: usize = reasons_a_is_pressed
                 .iter()
                 .map(|input| input.len())
                 .reduce(|a, b| a.max(b))
                 .unwrap_or_default();
 
-            let longest_b: u8 = reasons_b_is_pressed
+            let longest_b: usize = reasons_b_is_pressed
                 .iter()
                 .map(|input| input.len())
                 .reduce(|a, b| a.max(b))

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -74,7 +74,7 @@ pub struct InputMap<A: Actionlike> {
     /// The raw vector of [PetitSet]s used to store the input mapping,
     /// indexed by the `Actionlike::id` of `A`
     map: Vec<PetitSet<UserInput, 16>>,
-    per_mode_cap: Option<u8>,
+    per_mode_cap: Option<usize>,
     associated_gamepad: Option<Gamepad>,
     /// How should clashing (overlapping) inputs be handled?
     pub clash_strategy: ClashStrategy,
@@ -295,7 +295,7 @@ impl<A: Actionlike> InputMap<A> {
         action: A,
         input: impl Into<UserInput>,
         input_mode: Option<InputMode>,
-        index: u8,
+        index: usize,
     ) -> Option<UserInput> {
         let input = input.into();
         let removed = self.clear_at(action.clone(), input_mode, index);
@@ -310,7 +310,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Returns the per-[`InputMode`] cap on input bindings for every action
     ///
     /// Each individual action can have at most this many bindings, making them easier to display and configure.
-    pub fn per_mode_cap(&self) -> u8 {
+    pub fn per_mode_cap(&self) -> usize {
         if let Some(cap) = self.per_mode_cap {
             cap
         } else {
@@ -326,7 +326,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Supplying a value of 0 removes any per-mode cap.
     ///
     /// PANICS: `3 * per_mode_cap` cannot exceed the global `CAP`, as we need space to store all mappings.
-    pub fn set_per_mode_cap(&mut self, per_mode_cap: u8) -> InputMap<A> {
+    pub fn set_per_mode_cap(&mut self, per_mode_cap: usize) -> InputMap<A> {
         assert!(3 * per_mode_cap <= 16);
 
         if per_mode_cap == 0 {
@@ -468,8 +468,8 @@ impl<A: Actionlike> InputMap<A> {
     /// A maximum of `CAP` bindings across all input modes can be stored for each action,
     /// and insert operations will silently fail if used when `CAP` bindings already exist.
     #[must_use]
-    pub fn n_registered(&self, action: A, input_mode: Option<InputMode>) -> u8 {
-        self.get(action, input_mode).len() as u8
+    pub fn n_registered(&self, action: A, input_mode: Option<InputMode>) -> usize {
+        self.get(action, input_mode).len()
     }
 
     /// How many input bindings are registered total?
@@ -549,10 +549,10 @@ impl<A: Actionlike> InputMap<A> {
         &mut self,
         action: A,
         input_mode: Option<InputMode>,
-        index: u8,
+        index: usize,
     ) -> Option<UserInput> {
         let mut bindings = self.get(action.clone(), input_mode);
-        if (bindings.len() as u8) < index {
+        if bindings.len() < index {
             // Not enough matching bindings were found
             return None;
         }


### PR DESCRIPTION
In this PR I replaced all size-related functions to operate with usize instead of u8 since the conversion happens anyway under the hood.