### PR TITLE
Fix missing dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ itertools = "0.10"
 serde = {version = "1.0", features = ["derive"]}
 
 [dev-dependencies]
-bevy = {version = "0.6", default-features = false, features = ["bevy_sprite", "bevy_render"]}
+bevy = {version = "0.6", default-features = false, features = ["bevy_sprite", "bevy_text", "bevy_render", "bevy_core_pipeline", "x11"]}
 derive_more = "0.99"
 
 [lib]


### PR DESCRIPTION
To run examples there should be more dependencies. Otherwise you will get crash on startup.