### PR TITLE
Simplify InputMap

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,11 @@
   - this is more ergonomic (derive `Copy` when you can!), and somewhat faster in the overwhelming majority of uses
 - relaxed `Hash` and `Eq` bounds on `Actionlike`
 - `ActionState::state` and `set_state` methods renamed to `button_state` and `set_button_state` for clarity
+- removed `UserInput::Null`.
+- refactored `InputMap`.
+  - removed methods that works with specific input mode.
+  - removed `n_registered`, use `get(action).len()` instead.
+  - added `insert_at` / `remove_at` to insert / remove input at specific index.
 
 ### Bug fixes
 

--- a/src/buttonlike_user_input.rs
+++ b/src/buttonlike_user_input.rs
@@ -15,10 +15,6 @@ use serde::{Deserialize, Serialize};
 /// Suitable for use in an [`InputMap`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum UserInput {
-    /// A null user input, used for a safe default and error-handling
-    ///
-    /// This input can never be pressed.
-    Null,
     /// A single button
     Single(InputButton),
     /// A combination of buttons, pressed simultaneously
@@ -28,17 +24,10 @@ pub enum UserInput {
     Chord(PetitSet<InputButton, 8>),
 }
 
-impl Default for UserInput {
-    fn default() -> Self {
-        UserInput::Null
-    }
-}
-
 impl UserInput {
     /// Creates a [`UserInput::Chord`] from an iterator of [`Button`]s
     ///
     /// If `buttons` has a length of 1, a [`UserInput::Single`] variant will be returned instead.
-    /// If `buttons` has a length of 0, a [`UserInput::Null`] variant will be returned instead.
     pub fn chord(buttons: impl IntoIterator<Item = impl Into<InputButton>>) -> Self {
         // We can't just check the length unless we add an ExactSizeIterator bound :(
         let mut length: u8 = 0;
@@ -50,7 +39,6 @@ impl UserInput {
         }
 
         match length {
-            0 => UserInput::Null,
             1 => UserInput::Single(set.into_iter().next().unwrap()),
             _ => UserInput::Chord(set),
         }
@@ -60,7 +48,6 @@ impl UserInput {
     pub fn input_modes(&self) -> PetitSet<InputMode, 3> {
         let mut set = PetitSet::default();
         match self {
-            UserInput::Null => (),
             UserInput::Single(button) => {
                 set.insert((*button).into());
             }
@@ -93,14 +80,12 @@ impl UserInput {
                 }
                 false
             }
-            UserInput::Null => false,
         }
     }
 
     /// The number of buttons in the [`UserInput`]
     pub fn len(&self) -> usize {
         match self {
-            UserInput::Null => 0,
             UserInput::Single(_) => 1,
             UserInput::Chord(button_set) => button_set.len(),
         }
@@ -130,7 +115,6 @@ impl UserInput {
     /// ```
     pub fn n_matching(&self, buttons: &HashSet<InputButton>) -> usize {
         match self {
-            UserInput::Null => 0,
             UserInput::Single(button) => {
                 if buttons.contains(button) {
                     1
@@ -336,7 +320,6 @@ impl<'a> InputStreams<'a> {
         match input {
             UserInput::Single(button) => self.button_pressed(*button),
             UserInput::Chord(buttons) => self.all_buttons_pressed(buttons),
-            UserInput::Null => false,
         }
     }
 

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -134,9 +134,9 @@ impl<A: Actionlike> InputMap<A> {
     fn possible_clash(&self, action_a: A, action_b: A) -> Option<Clash<A>> {
         let mut clash = Clash::new(action_a.clone(), action_b.clone());
 
-        for input_a in self.get(action_a, None) {
-            for input_b in self.get(action_b.clone(), None) {
-                if input_a.clashes(&input_b) {
+        for input_a in self.get(action_a).iter() {
+            for input_b in self.get(action_b.clone()).iter() {
+                if input_a.clashes(input_b) {
                     clash.inputs_a.push(input_a.clone());
                     clash.inputs_b.push(input_b.clone());
                 }
@@ -426,8 +426,6 @@ mod tests {
 
         #[test]
         fn clash_caching() {
-            use crate::buttonlike_user_input::InputMode;
-
             let mut input_map = test_input_map();
             // Possible clashes are cached upon initialization
             assert_eq!(input_map.possible_clashes.len(), 12);
@@ -437,11 +435,8 @@ mod tests {
             assert_eq!(input_map.possible_clashes.len(), 15);
 
             // Possible clashes are cached upon binding removal
-            input_map.clear_action(Action::One, None);
+            input_map.clear_action(Action::One);
             assert_eq!(input_map.possible_clashes.len(), 9);
-
-            input_map.clear_action(Action::Two, Some(InputMode::Keyboard));
-            assert_eq!(input_map.possible_clashes.len(), 4);
         }
 
         #[test]

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -52,14 +52,11 @@ impl UserInput {
         use UserInput::*;
 
         match self {
-            Null => false,
             Single(self_button) => match other {
-                Null => false,
                 Single(_) => false,
                 Chord(other_set) => button_chord_clash(self_button, other_set),
             },
             Chord(self_set) => match other {
-                Null => false,
                 Single(other_button) => button_chord_clash(other_button, self_set),
                 Chord(other_set) => chord_chord_clash(self_set, other_set),
             },

--- a/src/display_impl.rs
+++ b/src/display_impl.rs
@@ -6,8 +6,6 @@ use std::fmt::Display;
 impl Display for UserInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            // The empty string
-            UserInput::Null => write!(f, ""),
             // The representation of the button
             UserInput::Single(button) => write!(f, "{button}"),
             // The representation of each button, seperated by "+"

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -165,6 +165,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Insert a mapping between `action` and `input`
     ///
     /// # Panics
+    ///
     /// Panics if the map is full and `input` is not a duplicate or `input` is [`UserInput::Null`].
     pub fn insert(&mut self, action: A, input: impl Into<UserInput>) -> &mut Self {
         let input = input.into();
@@ -187,6 +188,7 @@ impl<A: Actionlike> InputMap<A> {
     /// If a matching input already existed in the set, it will be moved to the supplied index. Any input that was previously there will be moved to the matching input’s original index.
     ///
     /// # Panics
+    ///
     /// Panics if the map is full and `input` is not a duplicate or `input` is [`UserInput::Null`].
     pub fn insert_at(&mut self, action: A, input: impl Into<UserInput>, index: usize) -> &mut Self {
         let input = input.into();
@@ -211,6 +213,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Any iterator that can be converted into a [`UserInput`] can be supplied.
     ///
     /// # Panics
+    ///
     /// Panics if the map is full and any of `inputs` is not a duplicate or any of `inputs` is [`UserInput::Null`].
     pub fn insert_multiple(
         &mut self,
@@ -229,6 +232,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Chords can also be added with the [insert](Self::insert) method, if the [`UserInput::Chord`] variant is constructed explicitly.
     ///
     /// # Panics
+    ///
     /// Panics if the map is full and `buttons` is not a duplicate.
     pub fn insert_chord(
         &mut self,

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -455,7 +455,7 @@ mod tests {
     }
 
     #[test]
-    pub fn chord_singleton_coercion() {
+    fn chord_singleton_coercion() {
         use crate::input_map::UserInput;
         use bevy::input::keyboard::KeyCode;
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -460,15 +460,6 @@ mod tests {
     }
 
     #[test]
-    fn empty_chords() {
-        use crate::input_map::InputButton;
-
-        let mut input_map_3 = InputMap::<Action>::default();
-        let empty_vec: Vec<InputButton> = Vec::default();
-        input_map_3.insert_chord(Action::Run, empty_vec);
-    }
-
-    #[test]
     fn input_clearing() {
         use bevy::input::keyboard::KeyCode;
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -166,14 +166,9 @@ impl<A: Actionlike> InputMap<A> {
     ///
     /// # Panics
     ///
-    /// Panics if the map is full and `input` is not a duplicate or `input` is [`UserInput::Null`].
+    /// Panics if the map is full and `input` is not a duplicate.
     pub fn insert(&mut self, action: A, input: impl Into<UserInput>) -> &mut Self {
         let input = input.into();
-
-        // Don't insert Null inputs into the map
-        if input == UserInput::Null {
-            panic!("Inserted input can't be {input:?}")
-        }
 
         self.map[action.index()].insert(input);
 
@@ -189,14 +184,9 @@ impl<A: Actionlike> InputMap<A> {
     ///
     /// # Panics
     ///
-    /// Panics if the map is full and `input` is not a duplicate or `input` is [`UserInput::Null`].
+    /// Panics if the map is full and `input` is not a duplicate.
     pub fn insert_at(&mut self, action: A, input: impl Into<UserInput>, index: usize) -> &mut Self {
         let input = input.into();
-
-        // Don't insert Null inputs into the map
-        if input == UserInput::Null {
-            panic!("Inserted input can't be {input:?}")
-        }
 
         self.map[action.index()].insert_at(input, index);
 
@@ -214,7 +204,7 @@ impl<A: Actionlike> InputMap<A> {
     ///
     /// # Panics
     ///
-    /// Panics if the map is full and any of `inputs` is not a duplicate or any of `inputs` is [`UserInput::Null`].
+    /// Panics if the map is full and any of `inputs` is not a duplicate.
     pub fn insert_multiple(
         &mut self,
         inputs: impl IntoIterator<Item = (A, impl Into<UserInput>)>,
@@ -470,11 +460,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn chord_null_coercion() {
+    fn empty_chords() {
         use crate::input_map::InputButton;
 
-        // Empty chords are converted to UserInput::Null which causes panic
         let mut input_map_3 = InputMap::<Action>::default();
         let empty_vec: Vec<InputButton> = Vec::default();
         input_map_3.insert_chord(Action::Run, empty_vec);

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -114,7 +114,6 @@ impl<'a> MutableInputStreams<'a> {
         let mut mouse_buttons: Vec<MouseButton> = Vec::default();
 
         match input_to_send {
-            UserInput::Null => (),
             UserInput::Single(button) => match button {
                 InputButton::Gamepad(gamepad_buttontype) => {
                     if let Some(gamepad) = self.associated_gamepad {


### PR DESCRIPTION
In this PR I make `InputMap` API more map-like. Also now it panics when something is going wrong instead of silently fails.

Should I replace `get` to return an iterator instead of `PetitiSet` directly?