### PR TITLE
Add InputMap::remove

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,6 +21,7 @@
   - removed methods that works with specific input mode.
   - removed `n_registered`, use `get(action).len()` instead.
   - added `insert_at` / `remove_at` to insert / remove input at specific index.
+  - added `remove` remove input for specific mapping.
   - use `usize` for sizes as in other Rust containers.
 
 ### Bug fixes

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -402,6 +402,18 @@ impl<A: Actionlike> InputMap<A> {
 
         found
     }
+
+    /// Removes the input for the `action`, if it exists
+    ///
+    /// Returns [`Some`] with index if the input was found, or [`None`] if no matching input was found.
+    pub fn remove(&mut self, action: A, input: impl Into<UserInput>) -> Option<usize> {
+        let index = self.map[action.index()].remove(&input.into());
+
+        // Cache clashes now, to ensure a clean state
+        self.cache_possible_clashes();
+
+        index
+    }
 }
 
 mod tests {


### PR DESCRIPTION
Works exactly as `PetitSet::remove`, but for specified `action`.