### PR TITLE
Changed `ActionState.button_states` inserts into direct assignments

### DIFF
--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -340,22 +340,19 @@ impl<A: Actionlike> ActionState<A> {
     /// ```
     #[inline]
     pub fn set_button_state(&mut self, action: A, state: VirtualButtonState) {
-        self.button_states.insert(action.index(), state);
+        self.button_states[action.index()] = state;
     }
 
     /// Press the `action` virtual button
     pub fn press(&mut self, action: A) {
         if let VirtualButtonState::Released(timing) = self.button_state(action.clone()) {
-            self.button_states.insert(
-                action.index(),
-                VirtualButtonState::Pressed(
-                    Timing {
-                        instant_started: None,
-                        current_duration: Duration::ZERO,
-                        previous_duration: timing.current_duration,
-                    },
-                    Vec::default(),
-                ),
+            self.button_states[action.index()] = VirtualButtonState::Pressed(
+                Timing {
+                    instant_started: None,
+                    current_duration: Duration::ZERO,
+                    previous_duration: timing.current_duration,
+                },
+                Vec::default(),
             );
         }
     }
@@ -363,14 +360,11 @@ impl<A: Actionlike> ActionState<A> {
     /// Release the `action` virtual button
     pub fn release(&mut self, action: A) {
         if let VirtualButtonState::Pressed(timing, _) = self.button_state(action.clone()) {
-            self.button_states.insert(
-                action.index(),
-                VirtualButtonState::Released(Timing {
-                    instant_started: None,
-                    current_duration: Duration::ZERO,
-                    previous_duration: timing.current_duration,
-                }),
-            );
+            self.button_states[action.index()] = VirtualButtonState::Released(Timing {
+                instant_started: None,
+                current_duration: Duration::ZERO,
+                previous_duration: timing.current_duration,
+            });
         }
     }
 

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -375,6 +375,19 @@ impl<A: Actionlike> ActionState<A> {
         }
     }
 
+    /// Changes the `action` to being held so calls to `just_pressed` return false.
+    pub fn make_held(&mut self, action: A) {
+        if let VirtualButtonState::Pressed(timing, user_input) = self.button_state(action.clone()) {
+            self.button_states[action.index()] = VirtualButtonState::Pressed(
+                Timing {
+                    instant_started: Some(Instant::now()),
+                    ..timing
+                },
+                user_input,
+            );
+        }
+    }
+
     /// Is this `action` currently pressed?
     #[inline]
     #[must_use]


### PR DESCRIPTION
Before this change, `.insert(...)` on `ActionState::button_states` would duplicate items. Changed those lines to direct assignments so duplication doesn't occur.