### PR TITLE
Refactor VirtualButtonState

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and a single input can result in multiple actions being triggered, which can be 
 
 - Full keyboard, mouse and joystick support for button-like inputs.
 - Effortlessly wire UI buttons to game state with one simple component!
-  - When clicked, your button will send a virtual button press to the corresponding entity.
+  - When clicked, your button will press the appropriate action on the corresponding entity.
 - Store all your input mappings in a single `InputMap` component
   - No more bespoke `Keybindings<KeyCode>`, `Keybindings<Gamepad>` headaches
 - Look up your current input state in a single `ActionState` component

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,16 +15,20 @@
 
 - if desired, users are now able to use the `ActionState` and `InputMap` structs as standalone resources
 - the crate name now uses underscores (`leafwing_input_manager`) rather than hyphens (`leafwing-input-manager`) to play nicer with `cargo`
+- the complex `run_in_state` API has been removed: now just manually insert and remove the `DisableInput<A: Actionlike>` resource
 - reverted change from by-reference to by-value APIs for `Actionlike` types
   - this is more ergonomic (derive `Copy` when you can!), and somewhat faster in the overwhelming majority of uses
 - relaxed `Hash` and `Eq` bounds on `Actionlike`
 - `ActionState::state` and `set_state` methods renamed to `button_state` and `set_button_state` for clarity
-- added `ActionState::reset(action)` API to reset an action without triggering `just_released`
-- fleshed out `VirtualButtonState` API for better parity with `ActionState`
-- removed `UserInput::Null`
+- simplified `VirtualButtonState` into a trivial enum `ButtonState`
+  - other metadata (e.g. timing information and reasons pressed) is stored in the `ActionData` struct
+  - users can now access the `ActionData` struct directly for each action in a `ActionState` struct, allowing full manual control for unusual needs
+- removed a layer of indirection for fetching timing information: simply call `action_state.current_duration(Action::Jump)`, rather than `action_state.button_state(Action::Jump).current_duration()`
+- fleshed out `ButtonState` API for better parity with `ActionState`
+- removed `UserInput::Null`: this was never helpful and bloated match statements
 - `InputManagerPlugin::run_in_state` was replaced with `InputDisabled<A: Actionlike>` resource
   - insert this resource when you want to suppress input collection, and remove it when you're done
-- renamed `InputManagerSystem::Reset` into `InputManagerSystem::Tick`.
+- renamed the `InputManagerSystem::Reset` system label to `InputManagerSystem::Tick`.
 - refactored `InputMap`
   - removed methods that works with specific input mode.
   - removed `n_registered`, use `get(action).len()` instead.

--- a/examples/arpg_indirection.rs
+++ b/examples/arpg_indirection.rs
@@ -113,7 +113,7 @@ fn copy_action_state(
             if let Some(&matching_ability) = ability_slot_map.get(&slot) {
                 // This copies the `VirtualButtonState` between the ActionStates,
                 // including information about how long the buttons have been pressed or released
-                ability_state.set_button_state(matching_ability, slot_state.button_state(slot));
+                ability_state.set_action_data(matching_ability, slot_state.action_data(slot));
             }
         }
     }

--- a/examples/arpg_indirection.rs
+++ b/examples/arpg_indirection.rs
@@ -2,7 +2,7 @@
 //! The first layer corresponds to a "slot",
 //! which can then be set to a second-layer "ability" of the player's choice
 //!
-//! This example demonstrates how to model that pattern by copying [`VirtualButtonState`]
+//! This example demonstrates how to model that pattern by copying [`ActionData`]
 //! between two distinct [`ActionState`] components.
 
 use bevy::prelude::*;
@@ -111,7 +111,7 @@ fn copy_action_state(
     for (slot_state, mut ability_state, ability_slot_map) in query.iter_mut() {
         for slot in Slot::variants() {
             if let Some(&matching_ability) = ability_slot_map.get(&slot) {
-                // This copies the `VirtualButtonState` between the ActionStates,
+                // This copies the `ActionData` between the ActionStates,
                 // including information about how long the buttons have been pressed or released
                 ability_state.set_action_data(matching_ability, slot_state.action_data(slot));
             }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -29,9 +29,9 @@ fn spawn_player(mut commands: Commands) {
         .spawn()
         .insert(Player)
         .insert_bundle(InputManagerBundle::<Action> {
-            // Stores "which virtual action buttons are currently pressed"
+            // Stores "which actions are currently pressed"
             action_state: ActionState::default(),
-            // Stores how those actions relate to inputs from your player
+            // Describes how to convert from player inputs into those actions
             input_map: InputMap::new([(Action::Jump, KeyCode::Space)]),
         });
 }
@@ -39,7 +39,7 @@ fn spawn_player(mut commands: Commands) {
 // Query for the `ActionState` component in your game logic systems!
 fn jump(query: Query<&ActionState<Action>, With<Player>>) {
     let action_state = query.single();
-    // Each action has a virtual button of its own that you can check
+    // Each action has a button-like state of its own that you can check
     if action_state.just_pressed(Action::Jump) {
         println!("I'm jumping!");
     }

--- a/examples/press_duration.rs
+++ b/examples/press_duration.rs
@@ -87,16 +87,14 @@ fn hold_dash(mut player_query: Query<(&ActionState<Action>, &mut Velocity), With
 
     let (action_state, mut velocity) = player_query.single_mut();
 
-    let left_state = action_state.action_data(Action::Left);
-    if left_state.just_released() {
+    if action_state.just_released(Action::Left) {
         // Accelerate left
-        velocity.x -= VELOCITY_RATIO * left_state.previous_duration().as_secs_f32();
+        velocity.x -= VELOCITY_RATIO * action_state.previous_duration(Action::Left).as_secs_f32();
     }
 
-    let right_state = action_state.action_data(Action::Right);
-    if right_state.just_released() {
+    if action_state.just_released(Action::Right) {
         // Accelerate right
-        velocity.x += VELOCITY_RATIO * right_state.previous_duration().as_secs_f32();
+        velocity.x += VELOCITY_RATIO * action_state.previous_duration(Action::Right).as_secs_f32();
     }
 }
 

--- a/examples/press_duration.rs
+++ b/examples/press_duration.rs
@@ -87,13 +87,13 @@ fn hold_dash(mut player_query: Query<(&ActionState<Action>, &mut Velocity), With
 
     let (action_state, mut velocity) = player_query.single_mut();
 
-    let left_state = action_state.button_state(Action::Left);
+    let left_state = action_state.action_data(Action::Left);
     if left_state.just_released() {
         // Accelerate left
         velocity.x -= VELOCITY_RATIO * left_state.previous_duration().as_secs_f32();
     }
 
-    let right_state = action_state.button_state(Action::Right);
+    let right_state = action_state.action_data(Action::Right);
     if right_state.just_released() {
         // Accelerate right
         velocity.x += VELOCITY_RATIO * right_state.previous_duration().as_secs_f32();

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -1,148 +1,53 @@
 //! Tools for working with button-like user inputs (mouse clicks, gamepad button, keyboard inputs and so on)
 //!
-use bevy_utils::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 
-use crate::user_input::UserInput;
-
-/// The current state of a particular virtual button,
-/// corresponding to a single [`Actionlike`] action.
-///
-/// Detailed timing information for the button can be accessed through the stored [`Timing`] value.
-/// When the button is pressed, you can inspect *why* it was pressed,
-/// allowing you to access information about e.g. the degree to which a trigger was depressed or the exact inputs used.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// The current state of a particular button,
+/// usually corresponding to a single [`Actionlike`] action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ButtonState {
-    /// This button is currently pressed
-    Pressed {
-        /// How long has this button been pressed for, and when was it first pressed?
-        timing: Timing,
-        /// What [`UserInput`]s (including their values) were responsible for this button being pressed?
-        reasons_pressed: Vec<UserInput>,
-    },
-    /// This button is currently released
-    Released {
-        /// How long has this button been released for, and when was it first pressed?
-        timing: Timing,
-    },
-}
-
-/// Stores the timing information for a [`VirtualButtonState`]
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct Timing {
-    /// The [`Instant`] at which the button was pressed or released
-    ///
-    /// Recorded as the [`Time`](bevy::core::Time) at the start of the tick after the state last changed.
-    /// If this is none, [`ActionState::update`] has not been called yet.
-    #[serde(skip)]
-    pub instant_started: Option<Instant>,
-    /// The [`Duration`] for which the button has been pressed or released.
-    ///
-    /// This begins at [`Duration::ZERO`] when [`ActionState::update`] is called.
-    pub current_duration: Duration,
-    /// The [`Duration`] for which the button was pressed or released before the state last changed.
-    pub previous_duration: Duration,
-}
-
-impl PartialOrd for Timing {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.current_duration.partial_cmp(&other.current_duration)
-    }
-}
-
-impl PartialOrd for ButtonState {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match self {
-            ButtonState::Pressed {
-                timing,
-                reasons_pressed: _,
-            } => match other {
-                ButtonState::Pressed {
-                    timing: other_timing,
-                    reasons_pressed: _,
-                } => timing.partial_cmp(other_timing),
-                ButtonState::Released {
-                    timing: other_timing,
-                } => timing.partial_cmp(other_timing),
-            },
-            ButtonState::Released { timing } => match other {
-                ButtonState::Pressed {
-                    timing: other_timing,
-                    reasons_pressed: _,
-                } => timing.partial_cmp(other_timing),
-                ButtonState::Released {
-                    timing: other_timing,
-                } => timing.partial_cmp(other_timing),
-            },
-        }
-    }
+    /// The button was pressed since the most recent tick
+    JustPressed,
+    /// This button is currently pressed (and was pressed before the most recent tick)
+    Pressed,
+    /// The button was released since the most recent tick
+    JustReleased,
+    /// This button is currently released (and was released before the most recent tick)
+    Released,
 }
 
 impl ButtonState {
-    /// A [`VirtualButtonState`] that is just pressed, with no history
-    pub const JUST_PRESSED: ButtonState = ButtonState::Pressed {
-        timing: Timing {
-            instant_started: None,
-            current_duration: Duration::ZERO,
-            previous_duration: Duration::ZERO,
-        },
-        reasons_pressed: Vec::new(),
-    };
-
-    /// A [`VirtualButtonState`] that is just released, with no history
-    pub const JUST_RELEASED: ButtonState = ButtonState::Released {
-        timing: Timing {
-            instant_started: None,
-            current_duration: Duration::ZERO,
-            previous_duration: Duration::ZERO,
-        },
-    };
-
-    /// Presses the virtual button
+    /// Causes just_pressed and just_released to become false
     ///
-    /// Records:
-    ///
-    /// * the [`Duration`] for which the button was previously held
-    /// * the [`Instant`] that this button was pressed
-    /// * the [`UserInput`]s responsible for this button being pressed
-    #[inline]
-    pub fn press(&mut self, instant_started: Option<Instant>, reasons_pressed: Vec<UserInput>) {
-        if let ButtonState::Released {
-            timing: previous_timing,
-        } = self
-        {
-            *self = ButtonState::Pressed {
-                timing: Timing {
-                    instant_started,
-                    current_duration: Duration::ZERO,
-                    previous_duration: previous_timing.current_duration,
-                },
-                reasons_pressed,
-            }
+    /// [`JustPressed`](ButtonState::JustPressed) becomes [`Pressed`](ButtonState::Pressed) and
+    /// [`JustReleased`](ButtonState::JustReleased) becomes [`Released`](ButtonState::Released)
+    pub fn tick(&mut self) {
+        use ButtonState::*;
+        *self = match self {
+            JustPressed => Pressed,
+            Pressed => Pressed,
+            JustReleased => Released,
+            Released => Released,
         }
     }
 
-    /// Releases the virtual button
+    /// Presses the button
     ///
-    /// Records:
-    ///
-    /// * the [`Duration`] for which the button was previously held
-    /// * the [`Instant`] that this button was pressed
-    /// * the [`UserInput`]s responsible for this button being pressed
+    /// It will be [`JustPressed`](ButtonState::JustPressed), unless it was already [`Pressed`](ButtonState::Pressed)
     #[inline]
-    pub fn release(&mut self, instant_started: Option<Instant>) {
-        if let ButtonState::Pressed {
-            timing: previous_timing,
-            reasons_pressed: _,
-        } = self
-        {
-            *self = ButtonState::Released {
-                timing: Timing {
-                    instant_started,
-                    current_duration: Duration::ZERO,
-                    previous_duration: previous_timing.current_duration,
-                },
-            }
+    pub fn press(&mut self) {
+        if *self != ButtonState::Pressed {
+            *self = ButtonState::JustPressed;
+        }
+    }
+
+    /// Releases the button
+    ///
+    /// It will be [`JustReleased`](ButtonState::JustReleased), unless it was already [`Released`](ButtonState::Released)
+    #[inline]
+    pub fn release(&mut self) {
+        if *self != ButtonState::Released {
+            *self = ButtonState::JustReleased;
         }
     }
 
@@ -150,165 +55,33 @@ impl ButtonState {
     #[inline]
     #[must_use]
     pub fn pressed(&self) -> bool {
-        match self {
-            ButtonState::Pressed {
-                timing: _,
-                reasons_pressed: _,
-            } => true,
-            ButtonState::Released { timing: _ } => false,
-        }
-    }
-
-    /// Advances the time for the virtual button
-    ///
-    /// The [`VirtualButtonState`] state will be advanced according to the `current_instant`.
-    /// - if no [`Instant`] is set, the `current_time` will be set as the initial time at which the button was pressed / released
-    /// - the [`Duration`] will advance to reflect elapsed time
-    #[inline]
-    pub fn tick(&mut self, current_instant: Instant) {
-        match self {
-            ButtonState::Pressed {
-                timing,
-                reasons_pressed: _,
-            } => match timing.instant_started {
-                Some(instant) => {
-                    timing.current_duration = current_instant - instant;
-                }
-                None => {
-                    timing.instant_started = Some(current_instant);
-                    timing.current_duration = Duration::ZERO;
-                }
-            },
-            ButtonState::Released { timing } => match timing.instant_started {
-                Some(instant) => {
-                    timing.current_duration = current_instant - instant;
-                }
-                None => {
-                    timing.instant_started = Some(current_instant);
-                    timing.current_duration = Duration::ZERO;
-                }
-            },
-        };
+        *self == ButtonState::Pressed || *self == ButtonState::JustPressed
     }
 
     /// Is the button currently released?
     #[inline]
     #[must_use]
     pub fn released(&self) -> bool {
-        match self {
-            ButtonState::Pressed {
-                timing: _,
-                reasons_pressed: _,
-            } => false,
-            ButtonState::Released { timing: _ } => true,
-        }
+        *self == ButtonState::Released || *self == ButtonState::JustReleased
     }
 
     /// Was the button pressed since the last time [`ActionState::update`] was called?
     #[inline]
     #[must_use]
     pub fn just_pressed(&self) -> bool {
-        match self {
-            ButtonState::Pressed {
-                timing,
-                reasons_pressed: _,
-            } => timing.instant_started.is_none(),
-            ButtonState::Released { timing: _ } => false,
-        }
+        *self == ButtonState::JustPressed
     }
 
     /// Was the button released since the last time [`ActionState::update`] was called?
     #[inline]
     #[must_use]
     pub fn just_released(&self) -> bool {
-        match self {
-            ButtonState::Pressed {
-                timing: _,
-                reasons_pressed: _,
-            } => false,
-            ButtonState::Released { timing } => timing.instant_started.is_none(),
-        }
-    }
-
-    /// The [`Instant`] at which the button was pressed or released
-    ///
-    /// Recorded as the [`Time`](bevy::core::Time) at the start of the tick after the state last changed.
-    /// If this is none, [`ActionState::update`] has not been called yet.
-    #[inline]
-    #[must_use]
-    pub fn instant_started(&self) -> Option<Instant> {
-        match self {
-            ButtonState::Pressed {
-                timing,
-                reasons_pressed: _,
-            } => timing.instant_started,
-            ButtonState::Released { timing } => timing.instant_started,
-        }
-    }
-
-    /// The [`Duration`] for which the button has been pressed or released.
-    ///
-    /// This begins at [`Duration::ZERO`] when [`ActionState::update`] is called.
-    #[inline]
-    #[must_use]
-    pub fn current_duration(&self) -> Duration {
-        match self {
-            ButtonState::Pressed {
-                timing,
-                reasons_pressed: _,
-            } => timing.current_duration,
-            ButtonState::Released { timing } => timing.current_duration,
-        }
-    }
-
-    /// The [`Duration`] for which the button was pressed or released before the state last changed.
-    #[inline]
-    #[must_use]
-    pub fn previous_duration(&self) -> Duration {
-        match self {
-            ButtonState::Pressed {
-                timing,
-                reasons_pressed: _,
-            } => timing.previous_duration,
-            ButtonState::Released { timing } => timing.previous_duration,
-        }
-    }
-
-    /// The reasons (in terms of [`UserInput`]) that the button was pressed
-    ///
-    /// If the button is currently released, the `Vec<UserInput`> returned will be empty
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use leafwing_input_manager::buttonlike::VirtualButtonState;
-    /// use bevy_input::keyboard::KeyCode;
-    ///
-    /// let mut state = VirtualButtonState::JUST_RELEASED;
-    ///
-    /// assert_eq!(state.reasons_pressed(), Vec::new());
-    ///
-    /// state.press(None, vec![KeyCode::Space.into()]);
-    /// assert!(state.pressed());
-    /// assert_eq!(state.reasons_pressed(), vec![KeyCode::Space.into()]);
-    /// ```
-    #[inline]
-    #[must_use]
-    pub fn reasons_pressed(&self) -> Vec<UserInput> {
-        match self {
-            ButtonState::Pressed {
-                timing: _,
-                reasons_pressed,
-            } => reasons_pressed.clone(),
-            ButtonState::Released { timing: _ } => Vec::new(),
-        }
+        *self == ButtonState::JustReleased
     }
 }
 
 impl Default for ButtonState {
     fn default() -> Self {
-        ButtonState::Released {
-            timing: Timing::default(),
-        }
+        ButtonState::Released
     }
 }

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -17,7 +17,7 @@ pub enum ButtonState {
 }
 
 impl ButtonState {
-    /// Causes just_pressed and just_released to become false
+    /// Causes [`just_pressed`](ButtonState::just_pressed) and [`just_released`](ButtonState::just_released) to become false
     ///
     /// [`JustPressed`](ButtonState::JustPressed) becomes [`Pressed`](ButtonState::Pressed) and
     /// [`JustReleased`](ButtonState::JustReleased) becomes [`Released`](ButtonState::Released)

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -12,7 +12,7 @@ use crate::user_input::UserInput;
 /// When the button is pressed, you can inspect *why* it was pressed,
 /// allowing you to access information about e.g. the degree to which a trigger was depressed or the exact inputs used.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum VirtualButtonState {
+pub enum ButtonState {
     /// This button is currently pressed
     Pressed {
         /// How long has this button been pressed for, and when was it first pressed?
@@ -50,27 +50,27 @@ impl PartialOrd for Timing {
     }
 }
 
-impl PartialOrd for VirtualButtonState {
+impl PartialOrd for ButtonState {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing,
                 reasons_pressed: _,
             } => match other {
-                VirtualButtonState::Pressed {
+                ButtonState::Pressed {
                     timing: other_timing,
                     reasons_pressed: _,
                 } => timing.partial_cmp(other_timing),
-                VirtualButtonState::Released {
+                ButtonState::Released {
                     timing: other_timing,
                 } => timing.partial_cmp(other_timing),
             },
-            VirtualButtonState::Released { timing } => match other {
-                VirtualButtonState::Pressed {
+            ButtonState::Released { timing } => match other {
+                ButtonState::Pressed {
                     timing: other_timing,
                     reasons_pressed: _,
                 } => timing.partial_cmp(other_timing),
-                VirtualButtonState::Released {
+                ButtonState::Released {
                     timing: other_timing,
                 } => timing.partial_cmp(other_timing),
             },
@@ -78,9 +78,9 @@ impl PartialOrd for VirtualButtonState {
     }
 }
 
-impl VirtualButtonState {
+impl ButtonState {
     /// A [`VirtualButtonState`] that is just pressed, with no history
-    pub const JUST_PRESSED: VirtualButtonState = VirtualButtonState::Pressed {
+    pub const JUST_PRESSED: ButtonState = ButtonState::Pressed {
         timing: Timing {
             instant_started: None,
             current_duration: Duration::ZERO,
@@ -90,7 +90,7 @@ impl VirtualButtonState {
     };
 
     /// A [`VirtualButtonState`] that is just released, with no history
-    pub const JUST_RELEASED: VirtualButtonState = VirtualButtonState::Released {
+    pub const JUST_RELEASED: ButtonState = ButtonState::Released {
         timing: Timing {
             instant_started: None,
             current_duration: Duration::ZERO,
@@ -107,11 +107,11 @@ impl VirtualButtonState {
     /// * the [`UserInput`]s responsible for this button being pressed
     #[inline]
     pub fn press(&mut self, instant_started: Option<Instant>, reasons_pressed: Vec<UserInput>) {
-        if let VirtualButtonState::Released {
+        if let ButtonState::Released {
             timing: previous_timing,
         } = self
         {
-            *self = VirtualButtonState::Pressed {
+            *self = ButtonState::Pressed {
                 timing: Timing {
                     instant_started,
                     current_duration: Duration::ZERO,
@@ -131,12 +131,12 @@ impl VirtualButtonState {
     /// * the [`UserInput`]s responsible for this button being pressed
     #[inline]
     pub fn release(&mut self, instant_started: Option<Instant>) {
-        if let VirtualButtonState::Pressed {
+        if let ButtonState::Pressed {
             timing: previous_timing,
             reasons_pressed: _,
         } = self
         {
-            *self = VirtualButtonState::Released {
+            *self = ButtonState::Released {
                 timing: Timing {
                     instant_started,
                     current_duration: Duration::ZERO,
@@ -151,11 +151,11 @@ impl VirtualButtonState {
     #[must_use]
     pub fn pressed(&self) -> bool {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing: _,
                 reasons_pressed: _,
             } => true,
-            VirtualButtonState::Released { timing: _ } => false,
+            ButtonState::Released { timing: _ } => false,
         }
     }
 
@@ -167,7 +167,7 @@ impl VirtualButtonState {
     #[inline]
     pub fn tick(&mut self, current_instant: Instant) {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing,
                 reasons_pressed: _,
             } => match timing.instant_started {
@@ -179,7 +179,7 @@ impl VirtualButtonState {
                     timing.current_duration = Duration::ZERO;
                 }
             },
-            VirtualButtonState::Released { timing } => match timing.instant_started {
+            ButtonState::Released { timing } => match timing.instant_started {
                 Some(instant) => {
                     timing.current_duration = current_instant - instant;
                 }
@@ -196,11 +196,11 @@ impl VirtualButtonState {
     #[must_use]
     pub fn released(&self) -> bool {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing: _,
                 reasons_pressed: _,
             } => false,
-            VirtualButtonState::Released { timing: _ } => true,
+            ButtonState::Released { timing: _ } => true,
         }
     }
 
@@ -209,11 +209,11 @@ impl VirtualButtonState {
     #[must_use]
     pub fn just_pressed(&self) -> bool {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing,
                 reasons_pressed: _,
             } => timing.instant_started.is_none(),
-            VirtualButtonState::Released { timing: _ } => false,
+            ButtonState::Released { timing: _ } => false,
         }
     }
 
@@ -222,11 +222,11 @@ impl VirtualButtonState {
     #[must_use]
     pub fn just_released(&self) -> bool {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing: _,
                 reasons_pressed: _,
             } => false,
-            VirtualButtonState::Released { timing } => timing.instant_started.is_none(),
+            ButtonState::Released { timing } => timing.instant_started.is_none(),
         }
     }
 
@@ -238,11 +238,11 @@ impl VirtualButtonState {
     #[must_use]
     pub fn instant_started(&self) -> Option<Instant> {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing,
                 reasons_pressed: _,
             } => timing.instant_started,
-            VirtualButtonState::Released { timing } => timing.instant_started,
+            ButtonState::Released { timing } => timing.instant_started,
         }
     }
 
@@ -253,11 +253,11 @@ impl VirtualButtonState {
     #[must_use]
     pub fn current_duration(&self) -> Duration {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing,
                 reasons_pressed: _,
             } => timing.current_duration,
-            VirtualButtonState::Released { timing } => timing.current_duration,
+            ButtonState::Released { timing } => timing.current_duration,
         }
     }
 
@@ -266,11 +266,11 @@ impl VirtualButtonState {
     #[must_use]
     pub fn previous_duration(&self) -> Duration {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing,
                 reasons_pressed: _,
             } => timing.previous_duration,
-            VirtualButtonState::Released { timing } => timing.previous_duration,
+            ButtonState::Released { timing } => timing.previous_duration,
         }
     }
 
@@ -296,18 +296,18 @@ impl VirtualButtonState {
     #[must_use]
     pub fn reasons_pressed(&self) -> Vec<UserInput> {
         match self {
-            VirtualButtonState::Pressed {
+            ButtonState::Pressed {
                 timing: _,
                 reasons_pressed,
             } => reasons_pressed.clone(),
-            VirtualButtonState::Released { timing: _ } => Vec::new(),
+            ButtonState::Released { timing: _ } => Vec::new(),
         }
     }
 }
 
-impl Default for VirtualButtonState {
+impl Default for ButtonState {
     fn default() -> Self {
-        VirtualButtonState::Released {
+        ButtonState::Released {
             timing: Timing::default(),
         }
     }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -1,6 +1,6 @@
 //! Handles clashing inputs into a [`InputMap`](crate::input_map::InputMap) in a configurable fashion.
 
-use crate::buttonlike::{Timing, VirtualButtonState};
+use crate::buttonlike::{ButtonState, Timing};
 use crate::input_map::InputMap;
 use crate::user_input::{InputButton, InputStreams, UserInput};
 use crate::Actionlike;
@@ -70,14 +70,14 @@ impl<A: Actionlike> InputMap<A> {
     /// The `usize` stored in `pressed_actions` corresponds to `Actionlike::index`
     pub fn handle_clashes(
         &self,
-        pressed_actions: &mut [VirtualButtonState],
+        pressed_actions: &mut [ButtonState],
         input_streams: &InputStreams,
         clash_strategy: ClashStrategy,
     ) {
         for clash in self.get_clashes(pressed_actions, input_streams) {
             // Remove the action in the pair that was overruled, if any
             if let Some(culled_action) = resolve_clash(&clash, clash_strategy, input_streams) {
-                pressed_actions[culled_action.index()] = VirtualButtonState::Released {
+                pressed_actions[culled_action.index()] = ButtonState::Released {
                     timing: Timing::default(),
                 };
             }
@@ -105,7 +105,7 @@ impl<A: Actionlike> InputMap<A> {
     #[must_use]
     fn get_clashes(
         &self,
-        pressed_actions: &[VirtualButtonState],
+        pressed_actions: &[ButtonState],
         input_streams: &InputStreams,
     ) -> Vec<Clash<A>> {
         let mut clashes = Vec::default();
@@ -523,10 +523,10 @@ mod tests {
             keyboard.press(Key1);
             keyboard.press(Key2);
 
-            let mut pressed_actions = vec![VirtualButtonState::default(); Action::N_VARIANTS];
-            pressed_actions[One.index()] = VirtualButtonState::JUST_PRESSED;
-            pressed_actions[Two.index()] = VirtualButtonState::JUST_PRESSED;
-            pressed_actions[OneAndTwo.index()] = VirtualButtonState::JUST_PRESSED;
+            let mut pressed_actions = vec![ButtonState::default(); Action::N_VARIANTS];
+            pressed_actions[One.index()] = ButtonState::JUST_PRESSED;
+            pressed_actions[Two.index()] = ButtonState::JUST_PRESSED;
+            pressed_actions[OneAndTwo.index()] = ButtonState::JUST_PRESSED;
 
             input_map.handle_clashes(
                 &mut pressed_actions,
@@ -534,8 +534,8 @@ mod tests {
                 ClashStrategy::PrioritizeLongest,
             );
 
-            let mut expected = vec![VirtualButtonState::default(); Action::N_VARIANTS];
-            expected[OneAndTwo.index()] = VirtualButtonState::JUST_PRESSED;
+            let mut expected = vec![ButtonState::default(); Action::N_VARIANTS];
+            expected[OneAndTwo.index()] = ButtonState::JUST_PRESSED;
 
             assert_eq!(pressed_actions, expected);
         }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -268,7 +268,7 @@ fn resolve_clash<A: Actionlike>(
         .filter(|&input| input_streams.input_pressed(input))
         .collect();
 
-    // Clashes are spurious if the virtual buttons are pressed for any non-clashing reason
+    // Clashes are spurious if the actions are pressed for any non-clashing reason
     for reason_a in reasons_a_is_pressed.iter() {
         for reason_b in reasons_b_is_pressed.iter() {
             // If there is at least one non-clashing reason why these buttons should both be pressed,

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -1,6 +1,6 @@
 //! Handles clashing inputs into a [`InputMap`](crate::input_map::InputMap) in a configurable fashion.
 
-use crate::buttonlike::{ButtonState, Timing};
+use crate::buttonlike::ButtonState;
 use crate::input_map::InputMap;
 use crate::user_input::{InputButton, InputStreams, UserInput};
 use crate::Actionlike;
@@ -77,9 +77,7 @@ impl<A: Actionlike> InputMap<A> {
         for clash in self.get_clashes(pressed_actions, input_streams) {
             // Remove the action in the pair that was overruled, if any
             if let Some(culled_action) = resolve_clash(&clash, clash_strategy, input_streams) {
-                pressed_actions[culled_action.index()] = ButtonState::Released {
-                    timing: Timing::default(),
-                };
+                pressed_actions[culled_action.index()] = ButtonState::Released;
             }
         }
     }
@@ -524,9 +522,9 @@ mod tests {
             keyboard.press(Key2);
 
             let mut pressed_actions = vec![ButtonState::default(); Action::N_VARIANTS];
-            pressed_actions[One.index()] = ButtonState::JUST_PRESSED;
-            pressed_actions[Two.index()] = ButtonState::JUST_PRESSED;
-            pressed_actions[OneAndTwo.index()] = ButtonState::JUST_PRESSED;
+            pressed_actions[One.index()] = ButtonState::JustPressed;
+            pressed_actions[Two.index()] = ButtonState::JustPressed;
+            pressed_actions[OneAndTwo.index()] = ButtonState::JustPressed;
 
             input_map.handle_clashes(
                 &mut pressed_actions,
@@ -535,7 +533,7 @@ mod tests {
             );
 
             let mut expected = vec![ButtonState::default(); Action::N_VARIANTS];
-            expected[OneAndTwo.index()] = ButtonState::JUST_PRESSED;
+            expected[OneAndTwo.index()] = ButtonState::JustPressed;
 
             assert_eq!(pressed_actions, expected);
         }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1,6 +1,6 @@
 //! This module contains [`InputMap`] and its supporting methods and impls.
 
-use crate::buttonlike::{Timing, VirtualButtonState};
+use crate::buttonlike::{ButtonState, Timing};
 use crate::clashing_inputs::ClashStrategy;
 use crate::user_input::{InputButton, InputStreams, UserInput};
 use crate::Actionlike;
@@ -302,8 +302,8 @@ impl<A: Actionlike> InputMap<A> {
         &self,
         input_streams: &InputStreams,
         clash_strategy: ClashStrategy,
-    ) -> Vec<VirtualButtonState> {
-        let mut pressed_actions = vec![VirtualButtonState::default(); A::N_VARIANTS];
+    ) -> Vec<ButtonState> {
+        let mut pressed_actions = vec![ButtonState::default(); A::N_VARIANTS];
 
         // Generate the raw action presses
         for action in A::variants() {
@@ -316,7 +316,7 @@ impl<A: Actionlike> InputMap<A> {
             }
 
             if !inputs.is_empty() {
-                pressed_actions[action.index()] = VirtualButtonState::Pressed {
+                pressed_actions[action.index()] = ButtonState::Pressed {
                     timing: Timing::default(),
                     reasons_pressed: inputs,
                 };

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1,6 +1,6 @@
 //! This module contains [`InputMap`] and its supporting methods and impls.
 
-use crate::buttonlike::{ButtonState, Timing};
+use crate::buttonlike::ButtonState;
 use crate::clashing_inputs::ClashStrategy;
 use crate::user_input::{InputButton, InputStreams, UserInput};
 use crate::Actionlike;
@@ -316,10 +316,7 @@ impl<A: Actionlike> InputMap<A> {
             }
 
             if !inputs.is_empty() {
-                pressed_actions[action.index()] = ButtonState::Pressed {
-                    timing: Timing::default(),
-                    reasons_pressed: inputs,
-                };
+                pressed_actions[action.index()] = ButtonState::JustPressed;
             }
         }
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -294,7 +294,7 @@ impl<A: Actionlike> InputMap<A> {
         action_data[action.index()].state.pressed()
     }
 
-    /// Returns the virtual buttons that are currently pressed, and the responsible [`UserInput`] for each action
+    /// Returns the actions that are currently pressed, and the responsible [`UserInput`] for each action
     ///
     /// Accounts for clashing inputs according to the [`ClashStrategy`].
     /// The position in each vector corresponds to `Actionlike::index()`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub mod prelude {
 
 /// Allows a type to be used as a gameplay action in an input-agnostic fashion
 ///
-/// Actions serve as "virtual buttons", cleanly abstracting over messy, customizable inputs
+/// Actions are modelled as "virtual buttons", cleanly abstracting over messy, customizable inputs
 /// in a way that can be easily consumed by your game logic.
 ///
 /// This trait should be implemented on the `A` type that you want to pass into [`InputManagerPlugin`](crate::plugin::InputManagerPlugin).

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,10 +12,10 @@ use bevy_input::InputSystem;
 #[cfg(feature = "ui")]
 use bevy_ui::UiSystem;
 
-/// A [`Plugin`] that collects [`Input`](bevy::input::Input) from disparate sources, producing an [`ActionState`](crate::action_state::ActionState) to consume in game logic
+/// A [`Plugin`] that collects [`Input`](bevy::input::Input) from disparate sources, producing an [`ActionState`](crate::action_state::ActionState) that can be conveniently checked
 ///
-/// This plugin needs to be passed in an [`Actionlike`] enum type that you've created for your game,
-/// which acts as a "virtual button" that can be comfortably consumed
+/// This plugin needs to be passed in an [`Actionlike`] enum type that you've created for your game.
+/// Each variant represents a "virtual button" whose state is stored in an [`ActionState`](crate::action_state::ActionState) struct.
 ///
 /// Each [`InputManagerBundle`](crate::InputManagerBundle) contains:
 ///  - an [`InputMap`](crate::input_map::InputMap) component, which stores an entity-specific mapping between the assorted input streams and an internal repesentation of "actions"

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -93,7 +93,7 @@ pub fn update_action_state<A: Actionlike>(
     }
 }
 
-/// When a button with a component `A` is clicked, press the corresponding virtual button in the [`ActionState`]
+/// When a button with a component of type `A` is clicked, press the corresponding action in the [`ActionState`]
 ///
 /// The action triggered is determined by the variant stored in your UI-defined button.
 #[cfg(feature = "ui")]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -71,8 +71,7 @@ pub fn update_action_state<A: Actionlike>(
             associated_gamepad: input_map.gamepad(),
         };
 
-        let pressed_set = input_map.which_pressed(&input_streams, *clash_strategy);
-        action_state.update(pressed_set);
+        action_state.update(input_map.which_pressed(&input_streams, *clash_strategy));
     }
 
     for (mut action_state, input_map) in query.iter_mut() {
@@ -83,9 +82,7 @@ pub fn update_action_state<A: Actionlike>(
             associated_gamepad: input_map.gamepad(),
         };
 
-        let pressed_set = input_map.which_pressed(&input_streams, *clash_strategy);
-
-        action_state.update(pressed_set);
+        action_state.update(input_map.which_pressed(&input_streams, *clash_strategy));
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -10,7 +10,6 @@ use crate::{
     user_input::InputStreams,
     Actionlike,
 };
-use bevy_core::Time;
 use bevy_ecs::prelude::*;
 use bevy_input::{gamepad::GamepadButton, keyboard::KeyCode, mouse::MouseButton, Input};
 #[cfg(feature = "ui")]
@@ -22,7 +21,6 @@ use bevy_ui::Interaction;
 /// Also resets the internal `pressed_this_tick` field, used to track whether or not to release an action.
 pub fn tick_action_state<A: Actionlike>(
     mut query: Query<&mut ActionState<A>>,
-    time: Res<Time>,
     disable_input: Option<Res<DisableInput<A>>>,
     action_state: Option<ResMut<ActionState<A>>>,
 ) {
@@ -31,19 +29,13 @@ pub fn tick_action_state<A: Actionlike>(
     }
 
     if let Some(mut action_state) = action_state {
-        action_state.tick(
-            time.last_update()
-                .expect("The `Time` resource has never been updated!"),
-        )
+        action_state.tick()
     }
 
     for mut action_state in query.iter_mut() {
         // If `Time` has not ever been advanced, something has gone horribly wrong
         // and the user probably forgot to add the `core_plugin`.
-        action_state.tick(
-            time.last_update()
-                .expect("The `Time` resource has never been updated!"),
-        );
+        action_state.tick();
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -10,8 +10,11 @@ use crate::{
     user_input::InputStreams,
     Actionlike,
 };
+
+use bevy_core::Time;
 use bevy_ecs::prelude::*;
 use bevy_input::{gamepad::GamepadButton, keyboard::KeyCode, mouse::MouseButton, Input};
+
 #[cfg(feature = "ui")]
 use bevy_ui::Interaction;
 
@@ -23,19 +26,23 @@ pub fn tick_action_state<A: Actionlike>(
     mut query: Query<&mut ActionState<A>>,
     disable_input: Option<Res<DisableInput<A>>>,
     action_state: Option<ResMut<ActionState<A>>>,
+    time: Res<Time>,
 ) {
+    // Time must be initialized and have ticked at least once
+    let current_time = time.last_update().unwrap();
+
     if disable_input.is_some() {
         return;
     }
 
     if let Some(mut action_state) = action_state {
-        action_state.tick()
+        action_state.tick(current_time);
     }
 
     for mut action_state in query.iter_mut() {
         // If `Time` has not ever been advanced, something has gone horribly wrong
         // and the user probably forgot to add the `core_plugin`.
-        action_state.tick();
+        action_state.tick(current_time);
     }
 }
 


### PR DESCRIPTION
# Problems

- Reasoning about and writing code for `VirtualButtonState` was a disaster, due to all of the extra information stored in it
- The default value for `VirtualButtonState` was "just released", and we could not change this due to the intertwining of button state and timing information.
- APIs to access timing information were not discoverable or ergonomic.

# Solution

- refactor `VirtualButtonState` into `ActionData`, which stores reasons pressed, timing and a simple `ButtonState` enum
- change the default value to "released", rather than "just released"
- expose convenient APIs to access timing information directly on `ActionState`
- give users the ability to directly control `ActionData` for when they want to do unusual things like "skip directly to pressed"