### PR TITLE
Add ActionState::freeze

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,7 +16,8 @@
 
 - if desired, users are now able to use the `ActionState` and `InputMap` structs as standalone resources
 - the crate name now uses underscores (`leafwing_input_manager`) rather than hyphens (`leafwing-input-manager`) to play nicer with `cargo`
-- the complex `run_in_state` API has been removed: now just manually insert and remove the `DisableInput<A: Actionlike>` resource
+- added the ability to freeze and unfreeze `ActionState`, causing it to ignore attempts to modify it
+  - the complex `run_in_state` API has been removed: now just `release_all`, `freeze` and `unfreeze` your `ActionState`s as needed
 - reverted change from by-reference to by-value APIs for `Actionlike` types
   - this is more ergonomic (derive `Copy` when you can!), and somewhat faster in the overwhelming majority of uses
 - relaxed `Hash` and `Eq` bounds on `Actionlike`

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -237,6 +237,8 @@ impl<A: Actionlike> ActionState<A> {
     }
 
     /// Releases all actions
+    ///
+    /// Note that this does not work while the action state is frozen: be sure to call this first!
     pub fn release_all(&mut self) {
         for action in A::variants() {
             self.release(action);
@@ -365,7 +367,9 @@ impl<A: Actionlike> ActionState<A> {
 
     /// Causes actions to ignore any requests to press or release them
     ///
-    /// Can be reversed via [`ActionState::unfreeze`]
+    /// Frequently combined with [`ActionState::release_all`],
+    /// in order to prevent actions from repeatedly firing while frozen.
+    /// Can be reversed via [`ActionState::unfreeze`].
     ///
     /// # Example
     ///

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 /// The current state of a particular button,
 /// usually corresponding to a single [`Actionlike`] action.
+///
+/// By default, buttons are [`ButtonState::Released`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ButtonState {
     /// The button was pressed since the most recent tick

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ pub mod prelude {
     pub use crate::input_map::InputMap;
     pub use crate::user_input::UserInput;
 
-    pub use crate::plugin::DisableInput;
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::{Actionlike, InputManagerBundle};
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -82,13 +82,8 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
                     update_action_state::<A>
                         .label(InputManagerSystem::Update)
                         .after(InputSystem),
-                )
-                .add_system_to_stage(
-                    CoreStage::PreUpdate,
-                    release_on_disable::<A>
-                        .label(InputManagerSystem::ReleaseOnDisable)
-                        .after(InputManagerSystem::Update),
                 );
+
                 #[cfg(feature = "ui")]
                 app.add_system_to_stage(
                     CoreStage::PreUpdate,
@@ -115,20 +110,6 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
 
         // Resources
         app.init_resource::<ClashStrategy>();
-    }
-}
-
-/// A resource which disables all input for the specified [`Actionlike`] type `A` if present in world
-pub struct DisableInput<A: Actionlike> {
-    _phantom: PhantomData<A>,
-}
-
-// Implement manually to not require [`Default`] for `A`
-impl<A: Actionlike> Default for DisableInput<A> {
-    fn default() -> Self {
-        Self {
-            _phantom: PhantomData::<A>,
-        }
     }
 }
 


### PR DESCRIPTION
1. Allows users to freeze (and unfreeze) entire action states, causing them to ignore any attempts to press or release their actions. 
2. Provides a fix to the underlying issue in #86.
3. We can reuse this functionality in combination with `release_all` to replace #106 with a more elegant and flexible API.