### PR TITLE
Replace freeze API with improved DisableInput resource

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,7 +28,7 @@
 - removed a layer of indirection for fetching timing information: simply call `action_state.current_duration(Action::Jump)`, rather than `action_state.button_state(Action::Jump).current_duration()`
 - fleshed out `ButtonState` API for better parity with `ActionState`
 - removed `UserInput::Null`: this was never helpful and bloated match statements
-- `InputManagerPlugin::run_in_state` was replaced with `InputDisabled<A: Actionlike>` resource
+- `InputManagerPlugin::run_in_state` was replaced with `ToggleActions<A: Actionlike>` resource which controls whether or not the [`ActionState`] / [`InputMap`] pairs of type `A` are active.
   - insert this resource when you want to suppress input collection, and remove it when you're done
 - renamed the `InputManagerSystem::Reset` system label to `InputManagerSystem::Tick`.
 - refactored `InputMap`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod prelude {
     pub use crate::input_map::InputMap;
     pub use crate::user_input::UserInput;
 
+    pub use crate::plugin::DisableInput;
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::{Actionlike, InputManagerBundle};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@ pub mod prelude {
     pub use crate::input_map::InputMap;
     pub use crate::user_input::UserInput;
 
-    pub use crate::plugin::DisableInput;
     pub use crate::plugin::InputManagerPlugin;
+    pub use crate::plugin::ToggleActions;
     pub use crate::{Actionlike, InputManagerBundle};
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -119,19 +119,25 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
         };
 
         // Resources
-        app.init_resource::<ClashStrategy>();
+        app.init_resource::<ToggleActions<A>>()
+            .init_resource::<ClashStrategy>();
     }
 }
 
-/// A resource which disables all input for the specified [`Actionlike`] type `A` if present in world
-pub struct DisableInput<A: Actionlike> {
+/// Controls whether or not the [`ActionState`] / [`InputMap`] pairs of type `A` are active
+pub struct ToggleActions<A: Actionlike> {
+    /// When this is false, [`ActionState`]'s corresponding to `A` will ignore user inputs
+    ///
+    /// When this is set to false, all corresponding [`ActionState`]s are released
+    pub enabled: bool,
     _phantom: PhantomData<A>,
 }
 
 // Implement manually to not require [`Default`] for `A`
-impl<A: Actionlike> Default for DisableInput<A> {
+impl<A: Actionlike> Default for ToggleActions<A> {
     fn default() -> Self {
         Self {
+            enabled: true,
             _phantom: PhantomData::<A>,
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,7 +22,8 @@ fn pay_respects(
         if action_state.pressed(Action::PayRespects) {
             respect.0 = true;
         }
-    } else if let Some(action_state) = action_state_resource {
+    }
+    if let Some(action_state) = action_state_resource {
         if action_state.pressed(Action::PayRespects) {
             respect.0 = true;
         }
@@ -91,10 +92,13 @@ fn disable_input() {
 
     let mut app = App::new();
 
+    // Here we spawn a player and creating a global action state to check if [`DisableInput`]
+    // releases correctly both
     app.add_plugins(MinimalPlugins)
         .add_plugin(InputPlugin)
         .add_system_to_stage(CoreStage::Last, reset_inputs.exclusive_system())
         .add_plugin(InputManagerPlugin::<Action>::default())
+        .add_startup_system(spawn_player)
         .init_resource::<ActionState<Action>>()
         .insert_resource(InputMap::<Action>::new([(Action::PayRespects, KeyCode::F)]))
         .init_resource::<Respect>()
@@ -107,10 +111,8 @@ fn disable_input() {
     let respect = app.world.get_resource::<Respect>().unwrap();
     assert_eq!(*respect, Respect(true));
 
-    // Release and freeze the action state
-    let mut action_state = app.world.get_resource_mut::<ActionState<Action>>().unwrap();
-    action_state.release_all();
-    action_state.freeze();
+    // Disable the input
+    app.init_resource::<DisableInput<Action>>();
 
     // Now, all respect has faded
     app.update();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -112,7 +112,11 @@ fn disable_input() {
     assert_eq!(*respect, Respect(true));
 
     // Disable the input
-    app.init_resource::<DisableInput<Action>>();
+    let mut toggle_actions = app
+        .world
+        .get_resource_mut::<ToggleActions<Action>>()
+        .unwrap();
+    toggle_actions.enabled = false;
 
     // Now, all respect has faded
     app.update();


### PR DESCRIPTION
`ActionState::freeze` was introduced to consume actions. But it turns out not very ergonomic. Also `freeze` requires to spawn an entity or init the resource should which is not always the case. In this iteration I used run criteria to make the code nicer.
Also I extended `disable_input` test to check if global and entity input both released on disable.