### PR TITLE
Add ActionState::consume

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,16 +11,16 @@
 - added `reasons_pressed` API on `ActionState`, which records the triggering inputs
   - you can use this to extract exact input information from analog inputs (like triggers or joysticks)
 - added the ability to release user inputs during input mocking
+- added `ActionState::consume(action)`, which allows you to consume a pressed action, ensuring it is not pressed until after it is otherwise released
 
 ### Usability
 
 - if desired, users are now able to use the `ActionState` and `InputMap` structs as standalone resources
 - the crate name now uses underscores (`leafwing_input_manager`) rather than hyphens (`leafwing-input-manager`) to play nicer with `cargo`
-- added the ability to freeze and unfreeze `ActionState`, causing it to ignore attempts to modify it
-  - the complex `run_in_state` API has been removed: now just `release_all`, `freeze` and `unfreeze` your `ActionState`s as needed
 - reverted change from by-reference to by-value APIs for `Actionlike` types
   - this is more ergonomic (derive `Copy` when you can!), and somewhat faster in the overwhelming majority of uses
 - relaxed `Hash` and `Eq` bounds on `Actionlike`
+- `InputManagerPlugin::run_in_state` was replaced with `ToggleActions<A: Actionlike>` resource which controls whether or not the [`ActionState`] / [`InputMap`] pairs of type `A` are active.
 - `ActionState::state` and `set_state` methods renamed to `button_state` and `set_button_state` for clarity
 - simplified `VirtualButtonState` into a trivial enum `ButtonState`
   - other metadata (e.g. timing information and reasons pressed) is stored in the `ActionData` struct
@@ -28,7 +28,6 @@
 - removed a layer of indirection for fetching timing information: simply call `action_state.current_duration(Action::Jump)`, rather than `action_state.button_state(Action::Jump).current_duration()`
 - fleshed out `ButtonState` API for better parity with `ActionState`
 - removed `UserInput::Null`: this was never helpful and bloated match statements
-- `InputManagerPlugin::run_in_state` was replaced with `ToggleActions<A: Actionlike>` resource which controls whether or not the [`ActionState`] / [`InputMap`] pairs of type `A` are active.
   - insert this resource when you want to suppress input collection, and remove it when you're done
 - renamed the `InputManagerSystem::Reset` system label to `InputManagerSystem::Tick`.
 - refactored `InputMap`

--- a/examples/consuming_actions.rs
+++ b/examples/consuming_actions.rs
@@ -1,0 +1,133 @@
+//! Demonstrates how to "consume" actions, so they can only be responded to by a single system
+
+use bevy::prelude::*;
+use bevy_ecs::system::Resource;
+use leafwing_input_manager::prelude::*;
+
+use menu_mocking::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(InputManagerPlugin::<MenuAction>::default())
+        .init_resource::<ActionState<MenuAction>>()
+        .insert_resource(InputMap::<MenuAction>::new([
+            (MenuAction::CloseWindow, KeyCode::Escape),
+            (MenuAction::OpenMainMenu, KeyCode::M),
+            (MenuAction::OpenSubMenu, KeyCode::S),
+        ]))
+        .init_resource::<MainMenu>()
+        .init_resource::<SubMenu>()
+        .add_system(report_menus)
+        .add_system(open_main_menu)
+        .add_system(open_sub_menu)
+        // We want to ensure that if both the main menu and submenu are open
+        // only the submenu is closed if the user hits (or holds) Escape
+        .add_system(close_menu::<SubMenu>.before("main_menu"))
+        // We can do this by ordering our systems and using `ActionState::consume`
+        .add_system(close_menu::<MainMenu>.label("main_menu"))
+        .run()
+}
+
+#[derive(Actionlike, Clone)]
+enum MenuAction {
+    CloseWindow,
+    OpenMainMenu,
+    OpenSubMenu,
+}
+
+// A simple "visualization" of app state
+fn report_menus(main_menu: Res<MainMenu>, submenu: Res<SubMenu>) {
+    if main_menu.is_changed() {
+        if main_menu.is_open() {
+            println!("The main menu is now open.")
+        } else {
+            println!("The main menu is now closed.")
+        }
+    }
+
+    if submenu.is_changed() {
+        if submenu.is_open() {
+            println!("The submenu is now open.")
+        } else {
+            println!("The submenu is now closed.")
+        }
+    }
+}
+
+fn open_main_menu(action_state: Res<ActionState<MenuAction>>, mut menu_state: ResMut<MainMenu>) {
+    if action_state.just_pressed(MenuAction::OpenMainMenu) && !menu_state.is_open() {
+        menu_state.open();
+    }
+}
+
+fn open_sub_menu(action_state: Res<ActionState<MenuAction>>, mut menu_state: ResMut<SubMenu>) {
+    if action_state.just_pressed(MenuAction::OpenSubMenu) && !menu_state.is_open() {
+        menu_state.open();
+    }
+}
+
+// We want to be sure that e.g. the submenu is closed in preference to the main menu if both are open
+// If you can, use a real focus system for this logic, but workarounds of this sort are necessary in bevy_egui
+// as it is an immediate mode UI library
+fn close_menu<M: Resource + Menu>(
+    mut action_state: ResMut<ActionState<MenuAction>>,
+    mut menu_status: ResMut<M>,
+) {
+    if action_state.pressed(MenuAction::CloseWindow) && menu_status.is_open() {
+        println!("Closing the top window, as requested.");
+        menu_status.close();
+        // Because the action is consumed, further systems won't see this action as pressed
+        // and it cannot be pressed again until after the next time it would be released.
+        action_state.consume(MenuAction::CloseWindow);
+    }
+}
+
+// A quick mock of some UI behavior for demonstration purposes
+mod menu_mocking {
+    pub trait Menu {
+        fn is_open(&self) -> bool;
+
+        fn open(&mut self);
+
+        fn close(&mut self);
+    }
+
+    #[derive(Default)]
+    pub struct MainMenu {
+        is_open: bool,
+    }
+
+    impl Menu for MainMenu {
+        fn is_open(&self) -> bool {
+            self.is_open
+        }
+
+        fn open(&mut self) {
+            self.is_open = true;
+        }
+
+        fn close(&mut self) {
+            self.is_open = false;
+        }
+    }
+
+    #[derive(Default)]
+    pub struct SubMenu {
+        is_open: bool,
+    }
+
+    impl Menu for SubMenu {
+        fn is_open(&self) -> bool {
+            self.is_open
+        }
+
+        fn open(&mut self) {
+            self.is_open = true;
+        }
+
+        fn close(&mut self) {
+            self.is_open = false;
+        }
+    }
+}


### PR DESCRIPTION
*Finally* fixes the problem outlined in #108. See the attached example for a nice demonstration of how this works and why it's useful.

Full credit to @shatur for the final idea on the mechanism.