### PR TITLE
Store ToggleActions data in an enum

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,10 @@
 - reduced required `derive_more` features
 - removed `thiserror` dependency
 
+### Docs
+
+- properly documented the `ToggleActions` functionality, for dynamically enabling and disabling actions
+
 ## Version 0.3
 
 ### Enhancements

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,12 @@
 
 - properly documented the `ToggleActions` functionality, for dynamically enabling and disabling actions
 
+## Version 0.4
+
+### Usability
+
+- `ToggleActions<A>` is now an enum, rather than storing an internal bool
+
 ## Version 0.3
 
 ### Enhancements

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -124,9 +124,11 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
     }
 }
 
-/// Controls whether or not the [`ActionState`] / [`InputMap`] pairs of type `A` are active
+/// Controls whether or not the [`ActionState`](crate::action_state::ActionState) / [`InputMap`](crate::input_map::InputMap) pairs of type `A` are active
+///
+/// If this resource does not exist, actions work normally, as if `ToggleActions::enabled == true`.
 pub struct ToggleActions<A: Actionlike> {
-    /// When this is false, [`ActionState`]'s corresponding to `A` will ignore user inputs
+    /// When this is false, [`ActionState`](crate::action_state::ActionState)'s corresponding to `A` will ignore user inputs
     ///
     /// When this is set to false, all corresponding [`ActionState`]s are released
     pub enabled: bool,
@@ -152,7 +154,7 @@ pub enum InputManagerSystem {
     Tick,
     /// Collects input data to update the [`ActionState`](crate::action_state::ActionState)
     Update,
-    /// Release all actions in all [`ActionState`]s if [`DisableInput`] was added
+    /// Release all actions in all [`ActionState`](crate::action_state::ActionState)s if [`ToggleActions`](crate::plugin::ToggleActions) was added
     ReleaseOnDisable,
     /// Manually control the [`ActionState`](crate::action_state::ActionState)
     ///

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -22,6 +22,10 @@ use bevy_ui::UiSystem;
 ///  - an [`ActionState`](crate::action_state::ActionState) component, which stores the current input state for that entity in an source-agnostic fashion
 ///
 /// ## Systems
+///
+/// All systems added by this plugin can be dynamically enabled and disabled by setting the value of the [`ToggleActions<A>`] resource is set.
+/// This can be useful when working with states to pause the game, navigate menus or so on.
+///
 /// - [`tick_action_state`](crate::systems::tick_action_state), which resets the `pressed` and `just_pressed` fields of the [`ActionState`](crate::action_state::ActionState) each frame
 ///     - labeled [`InputManagerSystem::Reset`]
 /// - [`update_action_state`](crate::systems::update_action_state), which collects [`Input`](bevy::input::Input) resources to update the [`ActionState`](crate::action_state::ActionState)
@@ -29,6 +33,7 @@ use bevy_ui::UiSystem;
 /// - [`update_action_state_from_interaction`](crate::systems::update_action_state_from_interaction), for triggering actions from buttons
 ///    - powers the [`ActionStateDriver`](crate::action_state::ActionStateDriver) component baseod on an [`Interaction`](bevy::ui::Interaction) component
 ///    - labeled [`InputManagerSystem::Update`]
+/// - [`release_on_disable`](crate::systems::release_on_disable), which resets action states when [`ToggleActions`] is flipped, to avoid persistent presses.
 pub struct InputManagerPlugin<A: Actionlike> {
     _phantom: PhantomData<A>,
     machine: Machine,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -165,7 +165,7 @@ pub fn process_action_diffs<A: Actionlike, ID: Eq + Component + Clone>(
     }
 }
 
-/// Release all inputs if [`DisableInput`] was added
+/// Release all inputs if the [`ToggleActions<A>`] resource exists and its `enabled` field is false.
 pub fn release_on_disable<A: Actionlike>(
     mut query: Query<&mut ActionState<A>>,
     resource: Option<ResMut<ActionState<A>>>,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -171,7 +171,7 @@ pub fn release_on_disable<A: Actionlike>(
     resource: Option<ResMut<ActionState<A>>>,
     toggle_actions: Res<ToggleActions<A>>,
 ) {
-    if toggle_actions.is_changed() && !toggle_actions.enabled {
+    if toggle_actions.is_changed() && *toggle_actions == ToggleActions::Disabled {
         for mut action_state in query.iter_mut() {
             action_state.release_all();
         }
@@ -183,7 +183,7 @@ pub fn release_on_disable<A: Actionlike>(
 
 /// Returns [`ShouldRun::No`] if [`DisableInput`] exists and [`ShouldRun::Yes`] otherwise
 pub(super) fn run_if_enabled<A: Actionlike>(toggle_actions: Res<ToggleActions<A>>) -> ShouldRun {
-    if toggle_actions.enabled {
+    if *toggle_actions == ToggleActions::Enabled {
         ShouldRun::Yes
     } else {
         ShouldRun::No


### PR DESCRIPTION
This is both prettier and clearer, but required some `PhantomData` shenanigans to make work.