### PR TITLE
update crate name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This ensures the examples are in-sync with the latest release.
 
 ### Getting started
 
-1. Add `leafwing_input_manager` to your `Cargo.toml`.
+1. Add `leafwing-input-manager` to your `Cargo.toml`.
 2. Create an enum of the logical actions you want to represent, and derive the `Actionlike` trait for it.
 3. Add the `InputManagerPlugin` to your `App`.
 4. Add the `InputManagerBundle` to your player entity (or entities!).


### PR DESCRIPTION
heya! I was using leafwing today and got a warning when I copy/pasted the name from the readme instructions because the crate name uses dashes and not underscores.

Not sure if you want it to show underscores intentionally but figured I'd PR a change anyway.

thanks for the crate, it's very useful!